### PR TITLE
Use arena pre-round time as hiding time

### DIFF
--- a/addons/sourcemod/gamedata/prophunt.txt
+++ b/addons/sourcemod/gamedata/prophunt.txt
@@ -104,11 +104,6 @@
 				"linux"		"477"
 				"windows"	"470"
 			}
-			"CTFScatterGun::HasKnockback"
-			{
-				"linux"		"494"
-				"windows"	"487"
-			}
 			"CTFWeaponBase::m_iWeaponMode"
 			{
 				"linux"		"1704"
@@ -234,13 +229,6 @@
 				"offset"	"CTFWeaponBaseMelee::Smack"
 				"hooktype"	"entity"
 				"return"	"void"
-				"this"		"entity"
-			}
-			"CTFScatterGun::HasKnockback"
-			{
-				"offset"	"CTFScatterGun::HasKnockback"
-				"hooktype"	"entity"
-				"return"	"bool"
 				"this"		"entity"
 			}
 		}

--- a/addons/sourcemod/scripting/prophunt.sp
+++ b/addons/sourcemod/scripting/prophunt.sp
@@ -432,9 +432,7 @@ bool SearchForEntityProps(int client, char[] message, int maxlength)
 		return false;
 	
 	// Set the player's prop
-	PHPlayer(client).PropType = Prop_Entity;
-	PHPlayer(client).PropIndex = EntIndexToEntRef(entity);
-	SetCustomModel(client, model);
+	SetCustomModel(client, model, Prop_Entity, EntIndexToEntRef(entity));
 	
 	// Copy skin of selected model
 	SetEntProp(client, Prop_Send, "m_bForcedSkin", true);
@@ -490,9 +488,7 @@ bool SearchForStaticProps(int client, char[] message, int maxlength)
 			continue;
 		
 		// Set the player's prop
-		PHPlayer(client).PropType = Prop_Static;
-		PHPlayer(client).PropIndex = i;
-		SetCustomModel(client, name);
+		SetCustomModel(client, name, Prop_Static, i);
 		
 		// Refill health during setup time
 		if (GameRules_GetRoundState() == RoundState_Preround)
@@ -558,10 +554,13 @@ bool DoModelSizeChecks(int client, const char[] model, const float mins[3], cons
 	return true;
 }
 
-void SetCustomModel(int client, const char[] model)
+void SetCustomModel(int client, const char[] model, PHPropType type, int index)
 {
 	// Reset everything first
 	ClearCustomModel(client);
+	
+	PHPlayer(client).PropType = type;
+	PHPlayer(client).PropIndex = index;
 	
 	SetVariantString(model);
 	AcceptEntityInput(client, "SetCustomModel");
@@ -600,6 +599,9 @@ void SetCustomModel(int client, const char[] model)
 
 void ClearCustomModel(int client)
 {
+	PHPlayer(client).PropType = Prop_None;
+	PHPlayer(client).PropIndex = -1;
+	
 	SetVariantString("");
 	AcceptEntityInput(client, "SetCustomModel");
 	

--- a/addons/sourcemod/scripting/prophunt/console.sp
+++ b/addons/sourcemod/scripting/prophunt/console.sp
@@ -115,7 +115,7 @@ public Action ConCmd_SetModel(int client, int args)
 	
 	for (int i = 0; i < target_count; i++)
 	{
-		SetCustomModel(target_list[i], model);
+		SetCustomModel(target_list[i], model, Prop_None, -1);
 	}
 	
 	if (tn_is_ml)

--- a/addons/sourcemod/scripting/prophunt/dhooks.sp
+++ b/addons/sourcemod/scripting/prophunt/dhooks.sp
@@ -199,6 +199,9 @@ public MRESReturn DHookCallback_Spawn_Pre(int player)
 			TF2_SetPlayerClass(player, GetRandomHunterClass(), _, false);
 	}
 	
+	// This needs to happen before the first call to CTFPlayer::GetMaxHealthForBuffing
+	ClearCustomModel(player);
+	
 	return MRES_Ignored;
 }
 

--- a/addons/sourcemod/scripting/prophunt/events.sp
+++ b/addons/sourcemod/scripting/prophunt/events.sp
@@ -41,6 +41,9 @@ public void Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast
 	{
 		AcceptEntityInput(client, "DisableShadow");
 		
+		// Show prop controls
+		ShowKeyHintText(client, "%t", "PH_PropControls");
+		
 		// Restore third-person setting to props
 		CreateTimer(0.1, Timer_SetForcedTauntCam, userid);
 	}
@@ -224,19 +227,15 @@ public void Event_ArenaRoundStart(Event event, const char[] name, bool dontBroad
 		}
 	}
 	
-	// End the truce
+	// End the truce if it was active
 	GameRules_SetProp("m_bTruceActive", false);
 	
+	// Kick cheaters out of the game now that they cannot respawn anymore
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client) && !IsFakeClient(client))
 		{
-			// Kick cheaters out of the game
 			QueryClientConVar(client, "r_staticpropinfo", ConVarQuery_StaticPropInfo);
-			
-			// Show prop controls
-			if (IsPlayerProp(client))
-				ShowKeyHintText(client, "%t", "PH_PropControls");
 		}
 	}
 }

--- a/addons/sourcemod/scripting/prophunt/events.sp
+++ b/addons/sourcemod/scripting/prophunt/events.sp
@@ -47,8 +47,6 @@ public void Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast
 		// Restore third-person setting to props
 		CreateTimer(0.1, Timer_SetForcedTauntCam, userid);
 	}
-	
-	ClearCustomModel(client);
 }
 
 public void Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast)


### PR DESCRIPTION
Instead of creating a setup timer ourselves, we use the arena pre-round time controlled by `tf_arena_preround_time`. This has the benefit of allowing players to spawn in during the hiding time, as well as everything else the game allows players to do during pre-round time (switching loadouts, no moving, etc.).

This also fixes prop health staying after the player suicides.