### PR TITLE
Move AddFileToDownloadsTable to OnMapStart

### DIFF
--- a/addons/sourcemod/scripting/prophunt.sp
+++ b/addons/sourcemod/scripting/prophunt.sp
@@ -172,8 +172,6 @@ public void OnPluginStart()
 	LoadTranslations("common.phrases");
 	LoadTranslations("prophunt.phrases");
 	
-	AddFileToDownloadsTable("sound/" ... SOUND_LAST_PROP);
-	
 	Console_Initialize();
 	ConVars_Initialize();
 	Events_Initialize();
@@ -244,7 +242,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 public void OnMapStart()
 {
 	g_IsMapRunning = true;
-	
+
+	AddFileToDownloadsTable("sound/" ... SOUND_LAST_PROP);
+
 	PrecacheSound("#" ... SOUND_LAST_PROP);
 	PrecacheSound(LOCK_SOUND);
 	PrecacheSound(UNLOCK_SOUND);

--- a/addons/sourcemod/scripting/prophunt.sp
+++ b/addons/sourcemod/scripting/prophunt.sp
@@ -242,9 +242,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 public void OnMapStart()
 {
 	g_IsMapRunning = true;
-
+	
 	AddFileToDownloadsTable("sound/" ... SOUND_LAST_PROP);
-
+	
 	PrecacheSound("#" ... SOUND_LAST_PROP);
 	PrecacheSound(LOCK_SOUND);
 	PrecacheSound(UNLOCK_SOUND);


### PR DESCRIPTION
I am sure `downloadables` string table is cleared when map starts.
If i understand correctly it happens [here](https://github.com/lua9520/source-engine-2018-hl2_src/blob/3bf9df6b2785fa6d951086978a3e66f49427166a/engine/DownloadListGenerator.cpp#L121)