### PR TITLE
Add features from Prop Hunt Redux

### DIFF
--- a/addons/sourcemod/scripting/prophunt.sp
+++ b/addons/sourcemod/scripting/prophunt.sp
@@ -131,6 +131,7 @@ ConVar ph_prop_min_size;
 ConVar ph_prop_max_size;
 ConVar ph_prop_select_distance;
 ConVar ph_prop_max_health;
+ConVar ph_prop_afterburn_immune;
 ConVar ph_hunter_damage_modifier_gun;
 ConVar ph_hunter_damage_modifier_melee;
 ConVar ph_hunter_damage_modifier_grapplinghook;
@@ -963,8 +964,10 @@ public Action Timer_PropPostSpawn(Handle timer, int serial)
 		AcceptEntityInput(client, "SetForcedTauntCam");
 		
 		// Apply gameplay conditions
-		TF2_AddCondition(client, TFCond_AfterburnImmune);
 		TF2_AddCondition(client, TFCond_SpawnOutline);
+		
+		if (ph_prop_afterburn_immune.BoolValue)
+			TF2_AddCondition(client, TFCond_AfterburnImmune);
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/prophunt.sp
+++ b/addons/sourcemod/scripting/prophunt.sp
@@ -143,6 +143,7 @@ ConVar ph_regenerate_last_prop;
 ConVar ph_bonus_refresh_interval;
 ConVar ph_chat_tip_interval;
 ConVar ph_healing_modifier;
+ConVar ph_flamethrower_velocity;
 ConVar ph_open_doors_after_setup;
 ConVar ph_setup_truce;
 ConVar ph_setup_time;
@@ -263,14 +264,17 @@ public Action TF2_CalcIsAttackCritical(int client, int weapon, char[] weaponname
 	if (!ShouldPlayerDealSelfDamage(client))
 		return Plugin_Continue;
 	
-	if (strcmp(weaponname, "tf_weapon_flamethrower") == 0)
-	{
-		// The damage of flame throwers is calculated as Damage x TimeFireDelay
-		float damage = GetWeaponDamage(weapon) * GetWeaponTimeFireDelay(weapon) * ph_hunter_damage_modifier_flamethrower.FloatValue;
-		int damageType = SDKCall_GetDamageType(weapon) | DMG_PREVENT_PHYSICS_FORCE;
-		
-		SDKHooks_TakeDamage(client, weapon, client, damage, damageType, weapon);
-	}
+	if (strcmp(weaponname, "tf_weapon_flamethrower") != 0)
+		return Plugin_Continue;
+	
+	// The damage of flame throwers is calculated as Damage x TimeFireDelay
+	float damage = GetWeaponDamage(weapon) * GetWeaponTimeFireDelay(weapon) * ph_hunter_damage_modifier_flamethrower.FloatValue;
+	int damageType = SDKCall_GetDamageType(weapon) | DMG_PREVENT_PHYSICS_FORCE;
+	
+	SDKHooks_TakeDamage(client, weapon, client, damage, damageType, weapon);
+	
+	// Allow Pyros to fly using their Flame Thrower
+	ApplyFlameThrowerVelocity(client);
 	
 	return Plugin_Continue;
 }
@@ -790,6 +794,26 @@ void DoTaunt(int client)
 	EmitGameSoundToAll(g_TauntSounds[GetRandomInt(0, sizeof(g_TauntSounds) - 1)], client);
 	
 	PHPlayer(client).NextTauntTime = GetGameTime() + 1.0;
+}
+
+void ApplyFlameThrowerVelocity(int client)
+{
+	float velocityToAdd = ph_flamethrower_velocity.FloatValue;
+	if (velocityToAdd <= 0.0)
+		return;
+	
+	float velocity[3];
+	GetEntPropVector(client, Prop_Data, "m_vecVelocity", velocity);
+	
+	// Scary values taken from Prop Hunt Redux
+	if (velocity[0] < (velocityToAdd / 2.0) && velocity[0] > -(velocityToAdd / 2.0))
+		velocity[0] *= 1.08;
+	if (velocity[1] < (velocityToAdd / 2.0) && velocity[1] > -(velocityToAdd / 2.0))
+		velocity[1] *= 1.08;
+	if (velocity[2] > 0 && velocity[2] < velocityToAdd)
+		velocity[2] = velocity[2] * 1.15;
+	
+	TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, velocity);
 }
 
 void CheckLastPropStanding(int client)

--- a/addons/sourcemod/scripting/prophunt/convars.sp
+++ b/addons/sourcemod/scripting/prophunt/convars.sp
@@ -50,6 +50,7 @@ void ConVars_Initialize()
 	ph_chat_tip_interval = CreateConVar("ph_chat_tip_interval", "240.0", "Interval at which tips are printed in chat, in seconds. Set to 0 to disable chat tips.");
 	ph_bonus_refresh_interval = CreateConVar("ph_bonus_refresh_interval", "60.0", "Interval at which the control point bonus refreshes, in seconds.");
 	ph_healing_modifier = CreateConVar("ph_healing_modifier", "0.25", "Modifier of the amount of healing received from continuous healing sources.");
+	ph_flamethrower_velocity = CreateConVar("ph_flamethrower_velocity", "300.0", "Velocity to add to the player while firing the Flame Thrower. Set to 0 to disable Flame Thrower flying.");
 	ph_open_doors_after_setup = CreateConVar("ph_open_doors_after_setup", "1", "When set, open all doors after setup time ends.");
 	ph_setup_truce = CreateConVar("ph_setup_truce", "0", "When set, props can not be damaged during setup.");
 	ph_setup_time = CreateConVar("ph_setup_time", "45", "Length of the setup time, in seconds.");


### PR DESCRIPTION
Closes #15

* Adds Flame Thrower flying, configurable with `ph_flamethrower_velocity`
  * Calculations are similar to Redux but happen at a different interval
* Adds a toggle for prop afterburn immunity, configurable with `ph_prop_afterburn_immune`